### PR TITLE
设置align为空，就可以不使用js进行定位相关（交由css解决）

### DIFF
--- a/src/overlay.js
+++ b/src/overlay.js
@@ -73,6 +73,10 @@ define(function(require, exports, module) {
             if (!isInDocument(this.element[0])) return;
 
             align || (align = this.get('align'));
+            
+            // 如果align为空，表示不需要使用js对齐
+            if(!align) return;
+            
             var isHidden = this.element.css('display') === 'none';
 
             // 在定位时，为避免元素高度不定，先显示出来


### PR DESCRIPTION
在某些场景下，只希望用css对齐，而不是js计算完成
目前 overlay 没有提供相关接口

``` js
// 这样就不会利用js计算定位了
new Overlay({
    align: null
})
```
